### PR TITLE
Don't try to create calendar entries when no date exists

### DIFF
--- a/custom_components/dvla/calendar.py
+++ b/custom_components/dvla/calendar.py
@@ -99,7 +99,11 @@ class DVLACalendarSensor(CoordinatorEntity[DVLACoordinator], CalendarEntity):
         """Return calendar events."""
         events = []
         for date_sensor_type in DATE_SENSOR_TYPES:
-            value = date.fromisoformat(self.coordinator.data.get(date_sensor_type.key))
+            raw_value = self.coordinator.data.get(date_sensor_type.key)
+            if not raw_value:
+                _LOGGER.warn(f'No date for {date_sensor_type.key}')
+                continue
+            value = date.fromisoformat(raw_value)
             if value >= start_date.date():
                 event_name = date_sensor_type.name.replace(' Date', '')
                 events.append(CalendarEvent(value, value, event_name))


### PR DESCRIPTION
I also hit #7 – my EV is still in its three-year MOT grace period and the API does not return `motExpiryDate`. I added a guard to the calendar entry creation code to skip it when no value is present.